### PR TITLE
Use TypeCache to get MethodInfo instead of custom assembly scanning code

### DIFF
--- a/Editor/DefineManagerSettings.cs
+++ b/Editor/DefineManagerSettings.cs
@@ -13,7 +13,6 @@ namespace Hibzz.DefineManager
 		private const string defineSettingsPath = "ProjectSettings/DefineManagerSettings.asset";
 
 		[SerializeField] internal List<DefineRegistrationData> DefineRegistery;
-		[SerializeField] internal List<string> IgnoreAssemblyList;
 
 		internal CategoryCollapseInfo CollapseInfo;
 
@@ -23,7 +22,6 @@ namespace Hibzz.DefineManager
 		private DefineManagerSettings()
         {
 			DefineRegistery = new List<DefineRegistrationData>();
-			IgnoreAssemblyList = new List<string>();
 			CollapseInfo = new CategoryCollapseInfo();
         }
 


### PR DESCRIPTION
As suggested by @shanecelis, this pull request modifies the code to use Unity's `TypeCache` system to scan for methods with the attribute `RegisterDefine` instead of the previously implemented assembly-based scan.

**Notes**
- Removed the ability to add assemblies to ignore during the scan. This was originally added as an alternative to ignore assemblies that didn't have any function with the `RegisterDefine` attribute for improving the performance of an assembly scan. Since unity caches the types and exposes them to us, we no longer have that performance penalty with `TypeCache`.
- Closes #5