### PR TITLE
Remove "ENABLE_DEFINE_MANAGER" define when package is uninstalled

### DIFF
--- a/Editor/DefineManagerSettings.cs
+++ b/Editor/DefineManagerSettings.cs
@@ -1,10 +1,9 @@
-using System.Collections;
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor;
 using UnityEngine;
 
-#if UNITY_EDITOR
 namespace Hibzz.DefineManager
 {
 	[System.Serializable]
@@ -20,10 +19,10 @@ namespace Hibzz.DefineManager
 		/// Constructor
 		/// </summary>
 		private DefineManagerSettings()
-        {
+		{
 			DefineRegistery = new List<DefineRegistrationData>();
 			CollapseInfo = new CategoryCollapseInfo();
-        }
+		}
 
 		/// <summary>
 		/// A singleton instance
@@ -34,13 +33,13 @@ namespace Hibzz.DefineManager
 		/// Get the define manager settings. If it doesn't exist create a new one
 		/// </summary>
 		internal static DefineManagerSettings GetOrCreateSettings()
-        {
+		{
 			// If we have singleton, then we return it
 			if(Instance != null) { return Instance; }
 
 			// if the file exists, populate the singleton and return it
 			if(File.Exists(defineSettingsPath))
-            {
+			{
 				string json_string = File.ReadAllText(defineSettingsPath);
 				Instance = JsonUtility.FromJson<DefineManagerSettings>(json_string);
 				return Instance;
@@ -50,54 +49,55 @@ namespace Hibzz.DefineManager
 			Instance = new DefineManagerSettings();
 			SaveSettings();
 			return Instance;
-        }
+		}
 
 		/// <summary>
 		/// Save the Define Manager Settings
 		/// </summary>
 		internal static void SaveSettings()
-        {
+		{
 			string json = JsonUtility.ToJson(Instance);
 			File.WriteAllText(defineSettingsPath, json);
 		}
 	}
 
 	internal class CategoryCollapseInfo
-    {
+	{
 		// data structure to store the category collapsed info
 		internal Dictionary<string, bool> collapseData;
 
 		// constructor
 		internal CategoryCollapseInfo()
-        {
+		{
 			collapseData = new Dictionary<string, bool>();
-        }
+		}
 
 		/// <summary>
 		/// Is the requested category collapsed or not?
 		/// </summary>
 		internal bool IsCollapsed(string category)
-        {
+		{
 			// return the collapse data if it's available
 			if(collapseData.ContainsKey(category))
-            {
+			{
 				return collapseData[category];
-            }
+			}
 
 			// else by default, it's false
 			return false;
-        }
+		}
 
 		/// <summary>
 		/// Toggle the collapse status of the requested category
 		/// </summary>
 		internal void Toggle(string category)
-        {
+		{
 			if(collapseData.ContainsKey(category))
-            {
+			{
 				collapseData[category] = !collapseData[category];
-            }
-        }
+			}
+		}
 	}
 }
+
 #endif

--- a/Editor/DefineManagerWindow.cs
+++ b/Editor/DefineManagerWindow.cs
@@ -1,8 +1,8 @@
+#if UNITY_EDITOR
+
 using UnityEngine;
 using UnityEditor;
-using System.Collections.Generic;
 
-#if UNITY_EDITOR
 namespace Hibzz.DefineManager
 {
 	internal class DefineManagerWindow : EditorWindow
@@ -79,7 +79,7 @@ namespace Hibzz.DefineManager
 		{
 			scrollpos = GUILayout.BeginScrollView(scrollpos, EditorStyleUtility.LeftTabStyle,
 							GUILayout.Height(position.height), GUILayout.Width(DefineListPaneWidth));
-            {
+			{
 				// variable used to track the last drawn category...
 				// This works because the system passes in define data sorted
 				// by category
@@ -174,7 +174,7 @@ namespace Hibzz.DefineManager
 			if(selectedData == null) { return; }
 
 			GUILayout.BeginVertical(EditorStyleUtility.RightTabStyle);
-            {
+			{
 				// Title + Define data
 				GUILayout.Label($"{selectedData.DisplayName}", EditorStyleUtility.TitleStyle);
 				GUILayout.Label($"Scripting Define: {selectedData.Define}");
@@ -216,7 +216,7 @@ namespace Hibzz.DefineManager
 			GUILayout.BeginHorizontal();
 			GUILayout.FlexibleSpace();
 
-            {
+			{
 				// pick the text based on if the data is installed or not
 				string buttonText = registrationData.IsInstalled ? "Remove" : "Install";
 
@@ -253,4 +253,5 @@ namespace Hibzz.DefineManager
 		#endif
 	}
 }
+
 #endif

--- a/Editor/EditorStyleUtility.cs
+++ b/Editor/EditorStyleUtility.cs
@@ -1,9 +1,7 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
-
 #if UNITY_EDITOR
+
+using UnityEngine;
+
 namespace Hibzz.DefineManager
 {
 	internal static class EditorStyleUtility
@@ -101,34 +99,35 @@ namespace Hibzz.DefineManager
 
 		private static GUIStyle _CategoryFontStyle;
 		internal static GUIStyle CategoryFontStyle
-        {
+		{
 			get
-            {
+			{
 				if(_CategoryFontStyle == null)
-                {
+				{
 					_CategoryFontStyle = new GUIStyle(GUI.skin.label); ;
 					_CategoryFontStyle.fontSize = 14;
-                }
+				}
 
 				return _CategoryFontStyle;
-            }
-        }
+			}
+		}
 
 		private static GUIStyle _TitleStyle;
 		internal static GUIStyle TitleStyle
-        {
+		{
 			get
-            {
+			{
 				if(_TitleStyle == null)
-                {
+				{
 					_TitleStyle = new GUIStyle(GUI.skin.label);
 					_TitleStyle.fontSize = 24;
 					_TitleStyle.fontStyle = FontStyle.Bold;
-                }
+				}
 
 				return _TitleStyle;
-            }
-        }
+			}
+		}
 	}
 }
+
 #endif

--- a/Editor/Establisher.cs
+++ b/Editor/Establisher.cs
@@ -1,22 +1,21 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine; 
+#if UNITY_EDITOR
+
 using UnityEditor;
 
-#if UNITY_EDITOR
 namespace Hibzz.DefineManager
 {
-    internal class Establisher
-    {
-        /// <summary>
-        /// If not added before, adds the define #ENABLE_DEFINE_MANAGER to the define list when the editor reloads
-        /// </summary>
-        [InitializeOnLoadMethod]
-        internal static void Establish()
+	internal class Establisher
+	{
+		/// <summary>
+		/// If not added before, adds the define #ENABLE_DEFINE_MANAGER to the define list when the editor reloads
+		/// </summary>
+		[InitializeOnLoadMethod]
+		internal static void Establish()
 		{
-            // Check and add the script
-            Manager.AddDefine("ENABLE_DEFINE_MANAGER");
+			// Check and add the script
+			Manager.AddDefine("ENABLE_DEFINE_MANAGER");
 		}
-    }
+	}
 }
+
 #endif

--- a/Editor/Establisher.cs
+++ b/Editor/Establisher.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 
 using UnityEditor;
+using UnityEditor.PackageManager;
 
 namespace Hibzz.DefineManager
 {
@@ -14,6 +15,32 @@ namespace Hibzz.DefineManager
 		{
 			// Check and add the script
 			Manager.AddDefine("ENABLE_DEFINE_MANAGER");
+
+			// Subscribe to the package manager event to monitor if the define
+			// manager is requested to be removed, so that appropriate cleanup
+			// can be performed
+			Events.registeringPackages += HandlePackageRemoval;
+		}
+
+		/// <summary>
+		/// Handles the removal of Define Manager and performs cleanup
+		/// </summary>
+		/// <param name="registrationInfo">The arguments passed by the package manager event</param>
+		static void HandlePackageRemoval(PackageRegistrationEventArgs registrationInfo)
+		{
+			// look through packages that are queued to be removed
+			foreach(var package in registrationInfo.removed)
+			{
+				// when the define manager is being removed by the user,
+				// perform a cleanup and remove the ENABLE_DEFINE_MANAGER
+				// define that indicates other packages and scripts that the
+				// define manager is installed
+				if(package.name == "com.hibzz.definemanager")
+				{
+					Manager.RemoveDefine("ENABLE_DEFINE_MANAGER");
+					return;
+				}
+			}	
 		}
 	}
 }

--- a/Editor/Manager.cs
+++ b/Editor/Manager.cs
@@ -1,11 +1,10 @@
-using System;
+#if UNITY_EDITOR
+
 using System.Collections.Generic;
 using System.Reflection;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-#if UNITY_EDITOR
 namespace Hibzz.DefineManager
 {
 	internal static class Manager
@@ -59,7 +58,7 @@ namespace Hibzz.DefineManager
 		/// Does it contain the requested define?
 		/// </summary>
 		internal static bool ContainDefine(string define)
-        {
+		{
 			// Get the define string from the player settings, which is a 
 			// semicolon seperated list of strings, and we split it
 			string definesString = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
@@ -121,7 +120,7 @@ namespace Hibzz.DefineManager
 		/// Refresh the collapsed category info
 		/// </summary>
 		private static void RefreshCollapsedCategoryInfo()
-        {
+		{
 			var settings = DefineManagerSettings.GetOrCreateSettings();
 			
 			var cacheData = settings.CollapseInfo.collapseData;
@@ -129,7 +128,7 @@ namespace Hibzz.DefineManager
 
 			string lastCategory = string.Empty;
 			foreach(var defineData in settings.DefineRegistery)
-            {
+			{
 				// skip if we've already processed the categorry
 				if(defineData.Category == lastCategory) { continue; }
 
@@ -137,9 +136,9 @@ namespace Hibzz.DefineManager
 				// collapsed or not, we use it during the refresh
 				bool collapsed = false;
 				if(cacheData.ContainsKey(defineData.Category))
-                {
+				{
 					collapsed = cacheData[defineData.Category];
-                }
+				}
 
 				// store the info to the new category info inside settings
 				settings.CollapseInfo.collapseData[defineData.Category] = collapsed;
@@ -147,7 +146,7 @@ namespace Hibzz.DefineManager
 				// update the last category flag
 				lastCategory = defineData.Category;
 			}
-        }
+		}
 
 		/// <summary>
 		/// Validate the method to return DefineRegistrationData and take no parameters
@@ -174,4 +173,5 @@ namespace Hibzz.DefineManager
 		}
 	}
 }
+
 #endif

--- a/Scripts/DefineRegistrationData.cs
+++ b/Scripts/DefineRegistrationData.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace Hibzz.DefineManager
 {
-	[System.Serializable]
+	[Serializable]
 	public class DefineRegistrationData : IComparable<DefineRegistrationData>
 	{
 		#region public settable values
@@ -56,7 +54,7 @@ namespace Hibzz.DefineManager
 		/// Initialize the data
 		/// </summary>
 		internal void Initialize()
-        {
+		{
 			// if already initialize, skip the process
 			if(Initialized) { return; }
 
@@ -68,7 +66,7 @@ namespace Hibzz.DefineManager
 
 			// mark the data as initialized
 			Initialized = true;
-        }
+		}
 		#endif
 	}
 }

--- a/Scripts/RegisterDefineAttribute.cs
+++ b/Scripts/RegisterDefineAttribute.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace Hibzz.DefineManager
 {
-    /// <summary>
-    /// Attribute used to register a define with the define manager
-    /// </summary>
-    /// <remarks><i>
-    /// The function must return <b>DefineRegistrationData</b>
-    /// </i></remarks>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class RegisterDefineAttribute : Attribute
-    {
-    }
+	/// <summary>
+	/// Attribute used to register a define with the define manager
+	/// </summary>
+	/// <remarks><i>
+	/// The function must return <b>DefineRegistrationData</b>
+	/// </i></remarks>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class RegisterDefineAttribute : Attribute
+	{
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.definemanager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "displayName": "hibzz.definemanager",
   "description": "A tool used to manage #defines in a project to enable/disable optional features to supporting packages and to produce cleaner and more efficient code",
   "author": {


### PR DESCRIPTION
This pull request makes a change to the Define Manager backend such that the `ENABLE_DEFINE_MANGER` define gets automatically removed went the package is uninstalled by the user using Unity's Package Manager.

- Bumps version to v1.2
- Tweaks to `#if UNITY_EDITOR` placement in the scripts