### PR TITLE
Move the button from Window submenu to Hibzz

### DIFF
--- a/Editor/DefineManagerWindow.cs
+++ b/Editor/DefineManagerWindow.cs
@@ -7,7 +7,7 @@ namespace Hibzz.DefineManager
 {
 	internal class DefineManagerWindow : EditorWindow
 	{
-		[MenuItem("Window/Define Manager")]
+		[MenuItem("Hibzz/Define Manager")]
 		private static void ShowEditor()
 		{
 			// start by refreshing the data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.definemanager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "hibzz.definemanager",
   "description": "A tool used to manage #defines in a project to enable/disable optional features to supporting packages and to produce cleaner and more efficient code",
   "author": {


### PR DESCRIPTION
This is an effort to unify the access location of all of my tools. I wish all package creators can agree on a standard location, but until then this will do.

- Meant to do it with the v1.2 update... oop 😭 
- Bump to v1.2.1